### PR TITLE
Bunnymark Test Without Sprite Nodes

### DIFF
--- a/BenchmarkCS_NoSprites.tscn
+++ b/BenchmarkCS_NoSprites.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://BenchmarkNoSprites.cs" type="Script" id=1]
+[ext_resource path="res://bunny.png" type="Texture" id=2]
+[ext_resource path="res://GUI.tscn" type="PackedScene" id=3]
+
+[node name="Scene" type="Node2D"]
+
+[node name="Sprites" type="Node2D" parent="."]
+
+script = ExtResource( 1 )
+_sections_unfolded = [ "Transform", "Z" ]
+TBunny = ExtResource( 2 )
+
+[node name="gui" parent="." instance=ExtResource( 3 )]
+
+

--- a/BenchmarkGD_NoSprites.gd
+++ b/BenchmarkGD_NoSprites.gd
@@ -1,0 +1,67 @@
+extends Node2D
+
+export(Texture) var t_bunny
+
+var bunnies = []
+var grav = 500
+var screen_size
+var elapsed = 0
+
+func _ready():
+	screen_size = get_viewport_rect().size
+	get_node("../gui/list/add").connect("pressed", self, "add_bunnies")
+	
+	for i in range(10): add_bunny()
+
+
+func _draw():
+	for bunny in bunnies:
+		draw_texture(t_bunny, bunny[0])
+	
+
+func _process(delta):
+	elapsed = elapsed + delta
+	screen_size = get_viewport_rect().size
+	if elapsed > 1:
+		get_node('../gui/list/fps').set_text('FPS: ' + str(Engine.get_frames_per_second()))
+		elapsed = 0
+	
+	for bunny in bunnies:
+		var pos = bunny[0]
+		var newPosition = bunny[1]
+		
+		pos.x += newPosition.x * delta
+		pos.y += newPosition.y * delta
+	
+		newPosition.y += grav * delta
+	
+		if pos.x > screen_size.x:
+			newPosition.x *= -1
+			pos.x = screen_size.x
+		
+		if pos.x < 0:
+			newPosition.x *= -1
+			pos.x = 0
+			
+		if pos.y > screen_size.y:
+			pos.y = screen_size.y
+			if randf() > 0.5:
+				newPosition.y = -(randi() % 1100 + 50)
+			else:
+				newPosition.y *= -0.85
+			
+		if pos.y < 0:
+			newPosition.y = 0
+			pos.y = 0
+		
+		bunny[0] = pos
+		bunny[1] = newPosition
+	update()
+
+func add_bunny():
+	bunnies.append([Vector2(screen_size.x / 2, screen_size.y / 2), Vector2(randi() % 200 + 50, randi() % 200 + 50)])
+	get_node('../gui/list/count').set_text('Bunny count: ' + str(bunnies.size()))
+
+func add_bunnies():
+	for i in range(0,100):
+		add_bunny()

--- a/BenchmarkGD_NoSprites.tscn
+++ b/BenchmarkGD_NoSprites.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://BenchmarkGD_NoSprites.gd" type="Script" id=1]
+[ext_resource path="res://bunny.png" type="Texture" id=2]
+[ext_resource path="res://GUI.tscn" type="PackedScene" id=3]
+
+[node name="Scene" type="Node2D"]
+
+position = Vector2( 35.1976, 30.6851 )
+
+[node name="Sprites" type="Node2D" parent="."]
+
+script = ExtResource( 1 )
+t_bunny = ExtResource( 2 )
+
+[node name="gui" parent="." instance=ExtResource( 3 )]
+
+margin_left = -35.0
+margin_top = -31.0
+margin_right = 115.0
+margin_bottom = 193.0
+
+

--- a/BenchmarkNoSprites.cs
+++ b/BenchmarkNoSprites.cs
@@ -1,0 +1,109 @@
+using Godot;
+using System;
+using System.Collections.Generic;
+
+public class BenchmarkNoSprites : Node2D
+{
+	private class Pair
+	{
+		public Vector2 Current;
+		public Vector2 Next;
+	}
+
+	[Export]
+	Texture TBunny;
+	List<Pair> bunnies = new List<Pair>();
+	int grav = 500;
+	float elapsed = 0.0f;
+	Vector2 screenSize;
+	Random random = new Random();
+
+	public override void _Ready()
+	{
+		screenSize = GetViewportRect().Size;
+		GetNode("../gui/list/add").Connect("pressed", this, "AddBunnies");
+
+		for (var i = 0; i < 10; i++)
+		{
+			AddBunny();
+		}
+	}
+	
+	public override void _Draw()
+	{
+		for (var i = 0; i < bunnies.Count; i++)
+			DrawTexture(TBunny, bunnies[i].Current);
+	}
+	
+	public override void _Process(float delta)
+	{
+		elapsed = elapsed + delta;
+		screenSize = GetViewportRect().Size;
+		if (elapsed > 1)
+		{
+			((Label)GetNode("../gui/list/fps")).Text = $"FPS: {Engine.GetFramesPerSecond()}";
+			elapsed = 0;
+		}
+
+		for (var i = 0; i < bunnies.Count; i++)
+		{
+			var bunny = bunnies[i];
+			var position = bunny.Current;
+			var newPosition = bunny.Next;
+
+			position.x += newPosition.x * delta;
+			position.y += newPosition.y * delta;
+
+			newPosition.y += grav * delta;
+
+			if (position.x > screenSize.x)
+			{
+				newPosition.x *= -1;
+				position.x = screenSize.x;
+			}
+
+			if (position.x < 0)
+			{
+				newPosition.x *= -1;
+				position.x = 0;
+			}
+
+			if (position.y > screenSize.y)
+			{
+				position.y = screenSize.y;
+				if (random.NextDouble() > 0.5)
+				{
+					newPosition.y = (random.Next() % 1100 + 50);
+				}
+				else
+				{
+					newPosition.y *= -0.85f;
+				}
+			}
+
+			if (position.y < 0)
+			{
+				newPosition.y = 0;
+				position.y = 0;
+			}
+			
+			bunny.Current = position;
+			bunny.Next = newPosition;
+		}
+		Update();
+	}
+
+	public void AddBunny()
+	{
+		bunnies.Add(new Pair() { Current = new Vector2(screenSize.x / 2, screenSize.y / 2), Next = new Vector2(random.Next() % 200 + 50, random.Next() % 200 + 50) });
+		((Label)GetNode("../gui/list/count")).Text = $"Bunny count: {bunnies.Count}";
+	}
+
+	public void AddBunnies()
+	{
+		for (var i = 0; i < 100; i++)
+		{
+			AddBunny();
+		}
+	}
+}

--- a/Bunnymark.csproj
+++ b/Bunnymark.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BenchmarkNoSprites.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BenchmarkCS.cs" />
   </ItemGroup>


### PR DESCRIPTION
I made a bunny mark test that draws all the bunnies using `_draw` and `draw_texture()` instead of creating Sprite nodes. Since Godot Engine lacks [dynamic batching](https://github.com/godotengine/godot/issues/1527),  I thought it might speed things up.

The resulting performance difference from BenchmarkGD is about +27% (5510 vs 7010) for my pc.

### Environment:
#### Hardware:
* Processor: i7-4770 3.40GHz
* GPU: AMD R9 270X
* RAM: 16 GiB DDR3
#### Build Info:
* OS: Korora Linux (Fedora 26)
* Compiler: gcc 7.2.1