### PR TITLE
Add No Sprite Bench for C++

### DIFF
--- a/BenchmarkCPP_NoSprites.tscn
+++ b/BenchmarkCPP_NoSprites.tscn
@@ -1,0 +1,34 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://GUI.tscn" type="PackedScene" id=1]
+
+[sub_resource type="GDNativeLibrary" id=1]
+
+platform/X11_32bit = ""
+platform/X11_64bit = "res://lib/BenchmarkCPPNS.so"
+platform/Windows_32bit = ""
+platform/Windows_64bit = ""
+platform/OSX = ""
+platform/Android = ""
+platform/iOS_32bit = ""
+platform/iOS_64bit = ""
+platform/WebAssembly = ""
+_sections_unfolded = [ "platform" ]
+
+[sub_resource type="NativeScript" id=2]
+
+resource_name = "BenchmarkCPPNS"
+class_name = "BenchmarkCPPNS"
+library = SubResource( 1 )
+_sections_unfolded = [ "Resource" ]
+
+[node name="Scene" type="Node2D"]
+
+[node name="Sprites" type="Node2D" parent="."]
+
+script = SubResource( 2 )
+_sections_unfolded = [ "Pause" ]
+
+[node name="gui" parent="." instance=ExtResource( 1 )]
+
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 comp:
 	clang -fPIC -o src/BenchmarkCPP.os -c src/BenchmarkCPP.cpp -g -O3 -std=c++14 -Icpp_bindings/include -Icpp_bindings/include/core -Igodot_headers
 	clang -o lib/BenchmarkCPP.so -shared src/BenchmarkCPP.os -Llib -lgodot_cpp_bindings
+	clang -fPIC -o src/BenchmarkCPPNS.os -c src/BenchmarkCPPNS.cpp -g -O3 -std=c++14 -Icpp_bindings/include -Icpp_bindings/include/core -Igodot_headers
+	clang -o lib/BenchmarkCPPNS.so -shared src/BenchmarkCPPNS.os -Llib -lgodot_cpp_bindings
+	

--- a/src/BenchmarkCPPNS.cpp
+++ b/src/BenchmarkCPPNS.cpp
@@ -1,0 +1,135 @@
+#include <vector>
+#include <tuple>
+#include <stdlib.h>
+#include <core/Godot.hpp>
+#include <core/GodotGlobal.hpp>
+#include <Node2D.hpp>
+#include <Texture.hpp>
+#include <Sprite.hpp>
+#include <Label.hpp>
+#include <ResourceLoader.hpp>
+#include <String.hpp>
+#include <Engine.hpp>
+#include <string> 
+#include <stdio.h>
+
+using namespace godot;
+
+class BenchmarkCPPNS : public GodotScript<Node2D> {
+        GODOT_CLASS(BenchmarkCPPNS);
+public:
+        Vector2 screenSize;
+        std::vector<std::tuple<Vector2, Vector2>> bunnies;
+        Ref<Texture> TBunny;
+        float elapsed = 0.0f;
+        float grav = 500; 
+
+        BenchmarkCPPNS() { }
+
+        void _ready() {
+                srand (time(NULL));
+                bunnies = {};
+                screenSize = owner->get_viewport_rect().size;
+                owner->get_node("../gui/list/add")->connect("pressed", owner, "add_bunnies");
+                TBunny = ResourceLoader::load("res://bunny.png");
+                for (int i = 0; i < 10; i++) {
+                        add_bunny();
+                }
+                owner->set_process(true);
+        }
+
+        void _draw() {
+                for (int i = 0; i < bunnies.size(); i++){
+                        owner->draw_texture(Ref<Texture>(TBunny), std::get<0>(bunnies[i]), Color(1.,1.,1.,1.), Ref<Texture>());
+                }
+        }
+
+        void _process(const float delta) {
+                elapsed += delta;
+                screenSize = owner->get_viewport_rect().size;
+                if (elapsed > 1) {
+                        String bunnies_count = std::to_string(Engine::get_frames_per_second()).c_str();
+                        String label = "FPS: " + bunnies_count;
+                        ((Label*)owner->get_node("../gui/list/fps"))->set_text(label); 
+                }
+
+                for (int i = 0; i < bunnies.size(); i++) {
+                        std::tuple<Vector2, Vector2> bunny = bunnies[i];
+                        Vector2 position = std::get<0>(bunny);
+                        Vector2 newPosition = std::get<1>(bunny);
+
+                        position.x += newPosition.x * delta;
+                        position.y += newPosition.y * delta;
+
+                        newPosition.y += grav * delta;
+
+                        if (position.x > screenSize.x)
+                        {
+                            newPosition.x *= -1;
+                            position.x = screenSize.x;
+                        }
+                        if (position.x < 0)
+                        {
+                            newPosition.x *= -1;
+                            position.x = 0;
+                        }
+
+                        if (position.y > screenSize.y)
+                        {
+                            position.y = screenSize.y;
+                            if ((double)rand() / RAND_MAX > 0.5)
+                            {
+                                newPosition.y = (rand() % 1100 + 50);
+                            }
+                            else
+                            {
+                                newPosition.y *= -0.85f;
+                            }
+                        }
+            
+                        if (position.y < 0)
+                        {
+                            newPosition.y = 0;
+                            position.y = 0;
+                        }
+                        bunnies[i] = std::make_tuple(position, newPosition);
+                }
+                owner->update();
+        }
+
+        void add_bunnies() {
+                for (int i = 0; i < 100; i++) {
+                        add_bunny();
+                }
+        }
+
+        void add_bunny() {
+                bunnies.push_back(std::make_tuple(Vector2(screenSize.x / 2.0, screenSize.y / 2.0), Vector2(rand()%200+50, rand()%200+50)));
+                String bunnies_count = std::to_string(bunnies.size()).c_str();
+                String label = "bunny count: " + bunnies_count;
+                ((Label*)owner->get_node("../gui/list/count"))->set_text(label);
+        }
+
+
+        static void _register_methods() {
+                register_method((char *)"_ready", &BenchmarkCPPNS::_ready);
+                register_method((char *)"_process", &BenchmarkCPPNS::_process);
+                register_method((char *)"_draw", &BenchmarkCPPNS::_draw);
+                register_method((char *)"add_bunnies", &BenchmarkCPPNS::add_bunnies);
+        }
+};
+
+/** GDNative Initialize **/
+GDNATIVE_INIT(godot_gdnative_init_options *options) {
+
+}
+
+/** GDNative Terminate **/
+GDNATIVE_TERMINATE(godot_gdnative_terminate_options *options) {
+
+}
+
+/** NativeScript Initialize **/
+NATIVESCRIPT_INIT() {
+        register_class<BenchmarkCPPNS>();
+}


### PR DESCRIPTION
After looking at the source code for CanvasItem.cpp, I found that I need to have all four arguments to make a successful call.

Performance difference: +36% (11 110 vs 15110).

Also sorry for not adding any of these to the gui menu.  I was going to but I ended up changing almost every scene in the process.