### PR TITLE
Added Nim Benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bin/
 cpp_bindings/
 godot_headers/
 *.os
+nimcache/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ cpp_bindings/
 godot_headers/
 *.os
 nimcache/
+_dlls/
+_godotapi/
+.nimcache/

--- a/BenchmarkNim.tscn
+++ b/BenchmarkNim.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://nimlib.tres" type="GDNativeLibrary" id=1]
+[ext_resource path="res://bunny.png" type="Texture" id=2]
+[ext_resource path="res://GUI.tscn" type="PackedScene" id=3]
+
+[sub_resource type="NativeScript" id=1]
+
+resource_name = "BenchmarkNim"
+class_name = "SpriteBenchmark"
+library = ExtResource( 1 )
+
+[node name="Scene" type="Node2D"]
+
+[node name="Sprites" type="Node2D" parent="."]
+
+script = SubResource( 1 )
+texture = ExtResource( 2 )
+
+[node name="gui" parent="." instance=ExtResource( 3 )]
+
+

--- a/BenchmarkNim_NoSprites.tscn
+++ b/BenchmarkNim_NoSprites.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://nimlib.tres" type="GDNativeLibrary" id=1]
+[ext_resource path="res://bunny.png" type="Texture" id=2]
+[ext_resource path="res://GUI.tscn" type="PackedScene" id=3]
+
+[sub_resource type="NativeScript" id=1]
+
+resource_name = "NoSpriteBenchmark"
+class_name = "NoSpriteBenchmark"
+library = ExtResource( 1 )
+
+[node name="Scene" type="Node2D"]
+
+[node name="Sprites" type="Node2D" parent="."]
+
+script = SubResource( 1 )
+texture = ExtResource( 2 )
+
+[node name="gui" parent="." instance=ExtResource( 3 )]
+
+

--- a/nakefile.nim
+++ b/nakefile.nim
@@ -1,0 +1,38 @@
+# Copyright 2017 Xored Software, Inc.
+
+import nake
+import os, ospaths, times
+import godotapigen
+
+proc genGodotApi() =
+  let godotBin = getEnv("GODOT_BIN")
+  if godotBin.isNil or godotBin.len == 0:
+    echo "GODOT_BIN environment variable is not set"
+    quit(-1)
+  if not fileExists(godotBin):
+    echo "Invalid GODOT_BIN path: " & godotBin
+    quit(-1)
+
+  const targetDir = "_godotapi"
+  createDir(targetDir)
+  const jsonFile = targetDir/"api.json"
+  if not fileExists(jsonFile) or
+     godotBin.getLastModificationTime() > jsonFile.getLastModificationTime():
+    direShell(godotBin, "--gdnative-generate-json-api", jsonFile)
+    if not fileExists(jsonFile):
+      echo "Failed to generate api.json"
+      quit(-1)
+
+    genApi(targetDir, jsonFile)
+
+task "build", "Builds the client for the current platform":
+  genGodotApi()
+  withDir "nim-src":
+    direShell("nimble", "make")
+
+task "clean", "Remove files produced by build":
+  removeDir(".nimcache")
+  removeDir("nim-src"/".nimcache")
+  removeDir("_godotapi")
+  removeDir("_dlls")
+removeFile("nakefile")

--- a/nim-src/bunnymark.nim
+++ b/nim-src/bunnymark.nim
@@ -1,0 +1,9 @@
+# Copyright 2017 Xored Software, Inc.
+
+## Import independent scene objects here
+## (no need to import everything, just independent roots)
+
+when not defined(release):
+  import segfaults # converts segfaults into NilAccessError
+import bunnymarkpkg/sprites
+import bunnymarkpkg/nosprites

--- a/nim-src/bunnymark.nimble
+++ b/nim-src/bunnymark.nimble
@@ -1,0 +1,34 @@
+version       = "0.1.0"
+author        = "Capital Ex"
+description   = "Godot-Nim Bunnymark"
+license       = "MIT"
+bin           = @["bunnymark"]
+
+requires "godot >= 0.6.0 & < 0.7.0"
+
+task make, "build":
+  const bitsPostfix = when sizeof(int) == 8: "_64" else: "_32"
+  const libFile =
+    when defined(windows):
+      "nim" & bitsPostfix & ".dll"
+    elif defined(ios):
+      "nim_ios" & bitsPostfix & ".dylib"
+    elif defined(macosx):
+      "nim_mac.dylib"
+    elif defined(android):
+      "nim_android.so"
+    elif defined(linux):
+      "nim_linux" & bitsPostfix & ".so"
+    else: nil
+  if libFile.isNil:
+    raise newException(OSError, "Unsupported platform")
+
+  exec "nimble build -y"
+  const dir = "../_dlls/"
+  const target = dir & libFile
+  mkDir(dir)
+  when defined(windows):
+    rmFile(target)
+    mvFile(bin[0] & ".exe", target)
+  else:
+    mvFile(bin[0], target)

--- a/nim-src/bunnymarkpkg/nim.cfg
+++ b/nim-src/bunnymarkpkg/nim.cfg
@@ -1,0 +1,2 @@
+--path:"$projectdir/../"
+--path:"$projectdir/../../_godotapi"

--- a/nim-src/bunnymarkpkg/nosprites.nim
+++ b/nim-src/bunnymarkpkg/nosprites.nim
@@ -1,0 +1,71 @@
+import random
+import godot, engine
+import node_2d, texture, sprite, viewport, label
+
+gdobj NoSpriteBenchmark of Node2d:
+    var texture* {.gdExport.}: Texture
+    var bunnies: seq[tuple[position: Vector2, motion: Vector2]] = @[]
+    var screen: Vector2
+    var viewport: Viewport
+    var elapsed: float = 0.0
+    var grav: float = 500.0
+    
+    method ready*() =
+        viewport = getViewport()
+        screen = viewport.size()
+        discard getNode("../gui/list/add").connect("pressed", self, "add_bunnies", newArray())
+        for _ in 1..10:
+            addBunny()
+        (getNode("../gui/list/count") as Label).text = "Bunny count: " & $bunnies.len
+        setProcess(true)
+    
+    method draw*() =
+        for bunny in bunnies.items:
+            drawTexture(texture, bunny.position, normalMap = texture)
+
+    method process*(delta: float64) =
+        elapsed += delta
+        screen = viewport.size()
+        if elapsed > 1:
+            (getNode("../gui/list/fps") as Label).text = "FPS: " & $getFramesPerSecond()
+            elapsed = 0
+
+        for bunny in bunnies.mitems:
+            var position = bunny.position
+            var motion = bunny.motion
+
+            position.x += motion.x * delta
+            position.y += motion.y * delta
+
+            motion.y += grav * delta
+
+            if position.x > screen.x:
+                motion.x *= -1
+                position.x = screen.x
+            
+            if position.x < 0:
+                motion.x *= -1
+                position.x = 0
+            
+            if position.y > screen.y:
+                position.y = screen.y
+                if (random(1.0) > 0.5):
+                    motion.y = (random(1100.0) + 50.0)
+                else:
+                    motion.y *= -0.85
+            
+            if position.y < 0:
+                motion.y = 0
+                position.y = 0
+            bunny.position = position
+            bunny.motion = motion
+
+        update()
+
+    proc addBunny*() =
+        bunnies.add((vec2(screen.x / 2, screen.y / 2), vec2(random(200.0) + 50.0, random(200.0) + 50.0)))
+    
+    proc addBunnies*() {.gdExport.} =
+        for _ in 1..100:
+            addBunny()
+        (getNode("../gui/list/count") as Label).text = "Bunny count: " & $bunnies.len

--- a/nim-src/bunnymarkpkg/sprites.nim
+++ b/nim-src/bunnymarkpkg/sprites.nim
@@ -1,0 +1,70 @@
+import random
+import godot, engine
+import node_2d, texture, sprite, viewport, label
+
+gdobj SpriteBenchmark of Node2d:
+    var texture* {.gdExport.}: Texture
+    var bunnies: seq[tuple[sprite: Sprite, motion: Vector2]] = @[]
+    var screen: Vector2
+    var viewport: Viewport
+    var elapsed: float = 0.0
+    var grav: float = 500.0
+    
+    method ready*() =
+        viewport = getViewport()
+        screen = viewport.size()
+        discard getNode("../gui/list/add").connect("pressed", self, "add_bunnies", newArray())
+        for _ in 1..10:
+            addBunny()
+        (getNode("../gui/list/count") as Label).text = "Bunny count: " & $bunnies.len
+        setProcess(true)
+        
+    method process*(delta: float64) =
+        elapsed += delta
+        screen = viewport.size()
+        if elapsed > 1:
+            (getNode("../gui/list/fps") as Label).text = "FPS: " & $getFramesPerSecond()
+            elapsed = 0
+
+        for bunny in bunnies.mitems:
+            var position = bunny.sprite.position
+            var motion = bunny.motion
+
+            position.x += motion.x * delta
+            position.y += motion.y * delta
+
+            motion.y += grav * delta
+
+            if position.x > screen.x:
+                motion.x *= -1
+                position.x = screen.x
+            
+            if position.x < 0:
+                motion.x *= -1
+                position.x = 0
+            
+            if position.y > screen.y:
+                position.y = screen.y
+                if (random(1.0) > 0.5):
+                    motion.y = (random(1100.0) + 50.0)
+                else:
+                    motion.y *= -0.85
+            
+            if position.y < 0:
+                motion.y = 0
+                position.y = 0
+            
+            bunny.sprite.position = position
+            bunny.motion = motion
+
+    proc addBunny*() =
+        let sprite = gdnew[Sprite]()
+        sprite.texture = texture
+        addChild(sprite)
+        sprite.position = vec2(screen.x / 2, screen.y / 2)
+        bunnies.add((sprite, vec2(random(200.0) + 50.0, random(200.0) + 50.0)))
+    
+    proc addBunnies*() {.gdExport.} =
+        for _ in 1..100:
+            addBunny()
+        (getNode("../gui/list/count") as Label).text = "Bunny count: " & $bunnies.len

--- a/nim-src/config.nims
+++ b/nim-src/config.nims
@@ -1,0 +1,48 @@
+import ospaths
+
+switch("nimcache", ".nimcache"/hostOS/hostCPU)
+
+when defined(macosx):
+  when defined(ios):
+    if hostCPU == "arm64":
+      switch("passC", "-arch arm64")
+      switch("passL", "-arch arm64")
+    elif hostCPU == "arm":
+      switch("passC", "-arch armv7")
+      switch("passL", "-arch armv7")
+    switch("passC", "-mios-version-min=9.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk")
+    switch("passL", "-mios-version-min=9.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk")
+  else:
+    switch("passL", "-framework Cocoa")
+elif defined(android):
+  let ndk = getEnv("ANDROID_NDK_ROOT")
+  let toolchain = getEnv("ANDROID_TOOLCHAIN")
+
+  if ndk.len == 0:
+    raise newException(OSError,
+      "ANDROID_NDK_ROOT environment variable is necessary for android build")
+  if toolchain.len == 0:
+    raise newException(OSError,
+      "ANDROID_TOOLCHAIN environment variable is necessary for android build")
+
+  const level = $16 # change this to the necessary API level
+  const arch = "arm"
+  let sysroot = "--sysroot=\"" & ndk & "/platforms/android-" & level & "/arch-" & arch & "/\""
+  switch("passL", sysroot)
+  switch("passC", sysroot)
+
+  switch("cc", "clang")
+  switch("arm.linux.clang.path", toolchain / "bin")
+  switch("arm.linux.clang.exe", arch & "-linux-androideabi-clang")
+  switch("arm.linux.clang.compilerexe", arch & "-linux-androideabi-clang")
+  switch("arm.linux.clang.linkerexe", arch & "-linux-androideabi-clang")
+elif defined(windows):
+  assert(sizeof(int) == 8)
+  switch("cc", "vcc")
+elif defined(linux):
+  switch("passC", "-fPIC")
+else:
+  raise newException(OSError, "Unsupported platform: " & hostOS)
+
+when not defined(release):
+  switch("debugger", "native")

--- a/nim-src/nim.cfg
+++ b/nim-src/nim.cfg
@@ -1,0 +1,7 @@
+--path:"$projectdir"
+--path:"$projectdir/*"
+--path:"$projectdir/../_godotapi"
+--app:lib
+-d:useRealtimeGc
+--noMain
+--warning[LockLevel]:off

--- a/nimlib.tres
+++ b/nimlib.tres
@@ -1,0 +1,15 @@
+[gd_resource type="GDNativeLibrary" format=2]
+
+[resource]
+
+platform/X11_32bit = "res://_dlls/nim_linux_32.so"
+platform/X11_64bit = "res://_dlls/nim_linux_64.so"
+platform/Windows_32bit = "res://_dlls/nim_32.dll"
+platform/Windows_64bit = "res://_dlls/nim_64.dll"
+platform/OSX = "res://_dlls/nim_mac.dylib"
+platform/Android = "res://nim_android.so"
+platform/iOS_32bit = "res://_dlls/nim_ios_32.dylib"
+platform/iOS_64bit = "res://_dlls/nim_ios_64.dylib"
+platform/WebAssembly = ""
+_sections_unfolded = [ "platform" ]
+


### PR DESCRIPTION
I've never programmed with Nim before, but I do have too much free time. So keep that in mind with this benchmark.

Anyways, It seems that for Nim calling out to Godot is a bit quicker than in C# (9610 [with --opt:speed 10210] bunnies vs 8410 bunnies).  Without --opt:speed in the nim.cfg C# get more bunnies in the spriteless test (13910 Nim vs 14110 C#).  With --opt:speed Nim draws more than C# (14710 Nim vs 14110 C#).