### PR TITLE
Update D for latest bindings

### DIFF
--- a/benchmarks/package.d
+++ b/benchmarks/package.d
@@ -9,26 +9,10 @@ public import bunnymark.v2;
 public import bunnymark.v1.draw_texture;
 public import bunnymark.v1.sprites;
 
-// This is supposed to work with latest godot-d, but it doesn't work with Godot 3.0
-
-// mixin GodotNativeLibrary!
-// (
-// 	"godot", // same as the symbol_prefix in the GDNativeLibrary resource
-
-// 	BunnymarkV2,
-// 	BunnymarkV1DrawTexture,
-// 	BunnymarkV1Sprites,
-
-// 	(GodotInitOptions o){ writeln("Library initialized"); },
-// 	(GodotTerminateOptions o){ writeln("Library terminated"); }
-// );
-
-mixin GodotNativeInit!
+mixin GodotNativeLibrary!
 (
     "godot_",
     BunnymarkV2,
     BunnymarkV1DrawTexture,
     BunnymarkV1Sprites,
 );
-
-mixin GodotNativeTerminate!("godot_");


### PR DESCRIPTION
Latest D bindings are backwards-compatible with Godot 3.0-stable now.

Minor note (added to the binding generator readme too): the bindings still need to be generated with a `gdnative_api.json` from current Godot source. The D compiler just needs the newer C functions from NativeScript 1.1 declared even if they're not used with 3.0-stable.