### PR TITLE
Changed the C# V1 benchmarks to use structs instead of classes

### DIFF
--- a/benchmarks/BunnymarkV1DrawTexture/cs/BunnymarkV1DrawTexture.cs
+++ b/benchmarks/BunnymarkV1DrawTexture/cs/BunnymarkV1DrawTexture.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 public class BunnymarkV1DrawTexture : Node2D
 {
-	private class Pair
+	private struct Pair
 	{
 		public Vector2 Current;
 		public Vector2 Next;
@@ -26,8 +26,9 @@ public class BunnymarkV1DrawTexture : Node2D
 	{
 		screenSize = GetViewportRect().Size;
 
-		foreach (var bunny in bunnies)
+		for (int i = 0; i < bunnies.Count; i++)
 		{
+			var bunny = bunnies[i];
 			var position = bunny.Current;
 			var newPosition = bunny.Next;
 
@@ -69,6 +70,8 @@ public class BunnymarkV1DrawTexture : Node2D
 			
 			bunny.Current = position;
 			bunny.Next = newPosition;
+			
+			bunnies[i] = bunny;
 		}
 
 		Update();

--- a/benchmarks/BunnymarkV1DrawTexture/cs/BunnymarkV1DrawTexture.cs
+++ b/benchmarks/BunnymarkV1DrawTexture/cs/BunnymarkV1DrawTexture.cs
@@ -10,7 +10,8 @@ public class BunnymarkV1DrawTexture : Node2D
 		public Vector2 Next;
 	}
 
-	List<Pair> bunnies = new List<Pair>();
+	Pair[] bunnies = new Pair[1024];
+	int count = 0;
 	Vector2 screenSize;
     Texture bunnyTexture = (Texture)GD.Load("res://images/godot_bunny.png");
 	Random random = new Random();
@@ -18,17 +19,17 @@ public class BunnymarkV1DrawTexture : Node2D
 
 	public override void _Draw()
 	{
-		foreach (var bunny in bunnies)
-			DrawTexture(bunnyTexture, bunny.Current);
+		for (int i = 0; i < count; i++)
+			DrawTexture(bunnyTexture, bunnies[i].Current);
 	}
 	
 	public override void _Process(float delta)
 	{
 		screenSize = GetViewportRect().Size;
 
-		for (int i = 0; i < bunnies.Count; i++)
+		for (int i = 0; i < count; i++)
 		{
-			var bunny = bunnies[i];
+			ref var bunny = ref bunnies[i];
 			var position = bunny.Current;
 			var newPosition = bunny.Next;
 
@@ -70,8 +71,6 @@ public class BunnymarkV1DrawTexture : Node2D
 			
 			bunny.Current = position;
 			bunny.Next = newPosition;
-			
-			bunnies[i] = bunny;
 		}
 
 		Update();
@@ -79,20 +78,25 @@ public class BunnymarkV1DrawTexture : Node2D
 
 	public void add_bunny()
 	{
-		bunnies.Add(new Pair() { Current = new Vector2(screenSize.x / 2, screenSize.y / 2), Next = new Vector2(random.Next() % 200 + 50, random.Next() % 200 + 50) });
+		if (count == bunnies.Length)
+		{
+			Array.Resize(ref bunnies, bunnies.Length * 2);
+		}
+		bunnies[count] = new Pair() { Current = new Vector2(screenSize.x / 2, screenSize.y / 2), Next = new Vector2(random.Next() % 200 + 50, random.Next() % 200 + 50) };
+		count++;
 	}
 
 	public void remove_bunny()
 	{
-		if (bunnies.Count == 0) {
+		if (count == 0) {
 			return;
 		}
 		
-		bunnies.RemoveAt(bunnies.Count - 1);
+		count--;
 	}
 
 	public void finish()
     {
-        EmitSignal("benchmark_finished", bunnies.Count);
+        EmitSignal("benchmark_finished", count);
     }
 }

--- a/benchmarks/BunnymarkV1Sprites/cs/BunnymarkV1Sprites.cs
+++ b/benchmarks/BunnymarkV1Sprites/cs/BunnymarkV1Sprites.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 public class BunnymarkV1Sprites : Node2D
 {
-    private class Pair
+    private struct Pair
     {
         public Sprite Sprite;
         public Vector2 Vector;
@@ -21,8 +21,9 @@ public class BunnymarkV1Sprites : Node2D
     {
         screenSize = GetViewportRect().Size;
 
-        foreach (var bunny in bunnies)
+        for (int i = 0; i < bunnies.Count; i++)
         {
+            var bunny = bunnies[i];
             var position = bunny.Sprite.Position;
             var newPosition = bunny.Vector;
 
@@ -64,6 +65,8 @@ public class BunnymarkV1Sprites : Node2D
 
             bunny.Sprite.Position = position;
             bunny.Vector = newPosition;
+
+            bunnies[i] = bunny;
         }
     }
 

--- a/benchmarks/BunnymarkV1Sprites/cs/BunnymarkV1Sprites.cs
+++ b/benchmarks/BunnymarkV1Sprites/cs/BunnymarkV1Sprites.cs
@@ -10,7 +10,8 @@ public class BunnymarkV1Sprites : Node2D
         public Vector2 Vector;
     }
 
-    List<Pair> bunnies = new List<Pair>();
+    Pair[] bunnies = new Pair[1024];
+    int count = 0;
     Vector2 screenSize;
 
     Texture bunnyTexture = (Texture)GD.Load("res://images/godot_bunny.png");
@@ -21,9 +22,9 @@ public class BunnymarkV1Sprites : Node2D
     {
         screenSize = GetViewportRect().Size;
 
-        for (int i = 0; i < bunnies.Count; i++)
+        for (int i = 0; i < count; i++)
         {
-            var bunny = bunnies[i];
+            ref var bunny = ref bunnies[i];
             var position = bunny.Sprite.Position;
             var newPosition = bunny.Vector;
 
@@ -65,8 +66,6 @@ public class BunnymarkV1Sprites : Node2D
 
             bunny.Sprite.Position = position;
             bunny.Vector = newPosition;
-
-            bunnies[i] = bunny;
         }
     }
 
@@ -76,22 +75,29 @@ public class BunnymarkV1Sprites : Node2D
         bunny.SetTexture(bunnyTexture);
         AddChild(bunny);
         bunny.Position = new Vector2(screenSize.x / 2, screenSize.y / 2);
-        bunnies.Add(new Pair() { Sprite = bunny, Vector = new Vector2(random.Next() % 200 + 50, random.Next() % 200 + 50) });
+
+        if (count == bunnies.Length)
+		{
+			Array.Resize(ref bunnies, bunnies.Length * 2);
+		}
+		bunnies[count] = new Pair() { Sprite = bunny, Vector = new Vector2(random.Next() % 200 + 50, random.Next() % 200 + 50) };
+		count++;
     }
 
     public void remove_bunny()
     {
-        if (bunnies.Count == 0) {
+        if (count == 0) {
 			return;
 		}
 
-        var bunny = bunnies[bunnies.Count - 1];
-        bunnies.RemoveAt(bunnies.Count - 1);
+        count--;
+        ref var bunny = bunnies[count]
         RemoveChild(bunny.Sprite);
+        bunny.Sprite = null;
     }
 
     public void finish()
     {
-        EmitSignal("benchmark_finished", bunnies.Count);
+        EmitSignal("benchmark_finished", count);
     }
 }


### PR DESCRIPTION
This should reduce pointer chasing and should make the implementation more comparable to the the C++ implementation. It should also increase the performance of these benchmarks.

I have not been able to run the benchmarks to see the difference, as i currently work on Windows.