### PR TITLE
Prevent leaking memory

### DIFF
--- a/Benchmarker.gd
+++ b/Benchmarker.gd
@@ -73,6 +73,7 @@ func start_benchmark(benchmark_name, language):
 func benchmark_finished(output):
 	print("benchmark output: ", output)
 	benchmark_container.remove_child(benchmark_node)
+	benchmark_node.queue_free()
 	write_result(output)
 	get_tree().quit()
 

--- a/benchmarks/BunnymarkV2/gd/BunnymarkV2.gd
+++ b/benchmarks/BunnymarkV2/gd/BunnymarkV2.gd
@@ -64,6 +64,7 @@ func remove_bunny():
 	var bunny = bunnies.get_child(child_count - 1)
 	bunny_speeds.pop_back()
 	bunnies.remove_child(bunny)
+	bunny.queue_free()
 
 func finish():
 	emit_signal("benchmark_finished", bunnies.get_child_count())


### PR DESCRIPTION
Remove child just remove node from scene tree  and this produce leaks which shows at exit:
```
ERROR: ~List: Condition ' _first != __null ' is true.
   At: ./core/self_list.h:112.
ERROR: ~List: Condition ' _first != __null ' is true.
   At: ./core/self_list.h:112.
WARNING: cleanup: ObjectDB Instances still exist!
   At: core/object.cpp:2069.
ERROR: clear: Resources Still in use at Exit!
   At: core/resource.cpp:473.
```